### PR TITLE
Restrict TimeTree event push page when un-run batches exist

### DIFF
--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -87,7 +87,7 @@ class ScheduleController extends AbstractController
                     ->paginate(config('app.PAGE_SIZE'))
                     ->appends($data),
                 'scheduleGenerations' => ScheduleGeneration::ofCalendar($id)->get(),
-                'unrunScheduleGenerations' => ScheduleGeneration::ofCalendar($id)
+                'unRunScheduleGenerations' => ScheduleGeneration::ofCalendar($id)
                     ->hasNonPushedEvents()
                     ->exists(),
                 'calendar' => Calendar::find($id)

--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -87,6 +87,9 @@ class ScheduleController extends AbstractController
                     ->paginate(config('app.PAGE_SIZE'))
                     ->appends($data),
                 'scheduleGenerations' => ScheduleGeneration::ofCalendar($id)->get(),
+                'unrunScheduleGenerations' => ScheduleGeneration::ofCalendar($id)
+                    ->hasNonPushedEvents()
+                    ->exists(),
                 'calendar' => Calendar::find($id)
             ]);
         } catch (Exception $e) {

--- a/app/Http/Controllers/ScheduleTimeTreeController.php
+++ b/app/Http/Controllers/ScheduleTimeTreeController.php
@@ -41,7 +41,9 @@ class ScheduleTimeTreeController extends AbstractController
     {
         try {
             return view('schedule.time-tree.push', [
-                'scheduleGenerations' => ScheduleGeneration::ofCalendar($id)->get(),
+                'scheduleGenerations' => ScheduleGeneration::ofCalendar($id)
+                    ->hasNonPushedEvents()
+                    ->get(),
                 'calendar' => Calendar::find($id)
             ]);
         } catch (Exception $e) {

--- a/app/Models/ScheduleGeneration.php
+++ b/app/Models/ScheduleGeneration.php
@@ -60,4 +60,20 @@ class ScheduleGeneration extends AbstractModel
     {
         return $query->where($this->table . '.batch', $batch);
     }
+
+    /**
+     *
+     * Scope a query to return schedule_generations with events that have not
+     * been pushed to TimeTree
+     *
+     * @param Builder $query
+     *
+     * @return Builder
+     */
+    public function scopeHasNonPushedEvents(Builder $query)
+    {
+        return $query->whereHas('schedule_events', function($query) {
+            $query->whereNull('time_tree_event_id');
+        });
+    }
 }

--- a/resources/views/schedule/list.blade.php
+++ b/resources/views/schedule/list.blade.php
@@ -12,7 +12,7 @@
         </div>
 
         <div class="d-flex align-items-center flex-wrap text-nowrap">
-            @if ($scheduleGenerations->count())
+            @if ($unrunScheduleGenerations)
                 <a href="{{route('time-tree-form', $calendar->id)}}" class="btn btn-outline-success btn-icon-text mr-2 mb-2 mb-md-0">
                     <i class="btn-icon-prepend" data-feather="cycle"></i>
                     Push Events to Time Tree

--- a/resources/views/schedule/list.blade.php
+++ b/resources/views/schedule/list.blade.php
@@ -12,7 +12,7 @@
         </div>
 
         <div class="d-flex align-items-center flex-wrap text-nowrap">
-            @if ($unrunScheduleGenerations)
+            @if ($unRunScheduleGenerations)
                 <a href="{{route('time-tree-form', $calendar->id)}}" class="btn btn-outline-success btn-icon-text mr-2 mb-2 mb-md-0">
                     <i class="btn-icon-prepend" data-feather="cycle"></i>
                     Push Events to Time Tree


### PR DESCRIPTION
- Add scope to pull ScheduleGeneration models when they contain schedule_events that haven't been pushed to TimeTree

- Add scope call to schedule list view and schedule TimeTree push view

- Display batch push buttons/dropdown based off of filtered ScheduleGeneration models